### PR TITLE
Ability to clear wallets except specified ones

### DIFF
--- a/BinanceChainKit.swift.podspec
+++ b/BinanceChainKit.swift.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name = 'BinanceChainKit.swift'
   spec.module_name = 'BinanceChainKit'
-  spec.version = '0.1'
+  spec.version = '0.1.1'
   spec.summary = 'Binance blockchain library for Swift'
   spec.description = <<-DESC
                        BinanceChainKit.swift implements BinanceChain protocol in Swift.

--- a/BinanceChainKit/BinanceChainKit/Core/BinanceChainKit.swift
+++ b/BinanceChainKit/BinanceChainKit/Core/BinanceChainKit.swift
@@ -163,7 +163,7 @@ extension BinanceChainKit: ITransactionManagerDelegate {
 
 extension BinanceChainKit {
 
-    public static func instance(words: [String], networkType: NetworkType = .mainNet, walletId: String = "default", minLogLevel: Logger.Level = .error) throws -> BinanceChainKit {
+    public static func instance(words: [String], networkType: NetworkType = .mainNet, walletId: String, minLogLevel: Logger.Level = .error) throws -> BinanceChainKit {
         let logger = Logger(minLogLevel: minLogLevel)
 
         let uniqueId = "\(walletId)-\(networkType)"
@@ -187,13 +187,14 @@ extension BinanceChainKit {
         return binanceChainKit
     }
 
-    public static func clear() throws {
+    public static func clear(exceptFor excludedFiles: [String]) throws {
         let fileManager = FileManager.default
+        let fileUrls = try fileManager.contentsOfDirectory(at: dataDirectoryUrl(), includingPropertiesForKeys: nil)
 
-        let urls = try fileManager.contentsOfDirectory(at: dataDirectoryUrl(), includingPropertiesForKeys: nil)
-
-        for url in urls {
-            try fileManager.removeItem(at: url)
+        for filename in fileUrls {
+            if !excludedFiles.contains(where: { filename.lastPathComponent.contains($0) }) {
+                try fileManager.removeItem(at: filename)
+            }
         }
     }
 

--- a/BinanceChainKitDemo/BinanceChainKitDemo/Core/Manager.swift
+++ b/BinanceChainKitDemo/BinanceChainKitDemo/Core/Manager.swift
@@ -17,7 +17,7 @@ class Manager {
     }
 
     func login(words: [String]) throws {
-        try BinanceChainKit.clear()
+        try BinanceChainKit.clear(exceptFor: ["walletId"])
         try initBinanceChainKit(words: words)
         save(words: words)
     }
@@ -35,6 +35,7 @@ class Manager {
         let binanceChainKit = try BinanceChainKit.instance(
                 words: words,
                 networkType: configuration.networkType,
+                walletId: "walletId",
                 minLogLevel: configuration.minLogLevel
         )
 


### PR DESCRIPTION
- BinanceChainKit#clear method receives a list of wallet ids which must remain after clearing
- Remove default value for walletId parameter in BinanceChainKit#instance methods
- Increased pods version

closes #2 